### PR TITLE
feat: Add flexShrink and flexGrow helper types

### DIFF
--- a/src/Feliz.Tailwind/Modifiers.fs
+++ b/src/Feliz.Tailwind/Modifiers.fs
@@ -216,6 +216,16 @@ type flexDirection =
     static member inline flexColReserve = prop.className "flex-col-reserve"
 
 [<Erase>]
+type flexShrink =
+    static member inline flexShrink = prop.className "flex-shrink"
+    static member inline flexShrink0 = prop.className "flex-shrink-0"
+
+[<Erase>]
+type flexGrow =
+    static member inline flexGrow = prop.className "flex-grow"
+    static member inline flexGrow0 = prop.className "flex-grow-0"
+
+[<Erase>]
 type fontSize =
     static member inline textXs = prop.className "text-xs"
     static member inline textSm = prop.className "text-sm"


### PR DESCRIPTION
Added missing Tailwind CSS flex utility classes:
- flexShrink type with flexShrink and flexShrink0 helpers
- flexGrow type with flexGrow and flexGrow0 helpers

These helpers enable type-safe usage of flex-shrink and flex-grow utilities which are commonly needed for flexbox layouts.

Resolves common use cases like:
- flexShrink.flexShrink0 for preventing flex items from shrinking
- flexGrow.flexGrow for allowing flex items to grow